### PR TITLE
往HostGroup中添加机器的时候如果发现机器名不存在，就直接插入host表

### DIFF
--- a/web/model/group_host.py
+++ b/web/model/group_host.py
@@ -21,7 +21,10 @@ class GroupHost(Bean):
     def bind(cls, group_id, hostname):
         h = Host.read('hostname = %s', [hostname])
         if not h:
-            return 'no such host'
+            Host.create(hostname)
+            h = Host.read('hostname = %s', [hostname])
+            if not h:
+                return 'host auto add failed'
 
         if cls.exists('grp_id = %s and host_id = %s', [group_id, h.id]):
             return 'already existent'

--- a/web/model/host.py
+++ b/web/model/host.py
@@ -55,6 +55,12 @@ class Host(Bean):
         return ret
 
     @classmethod
+    def create(cls, hostname):
+        if cls.exists('hostname=%s', [hostname]):
+            return
+        cls.insert({'hostname': hostname})
+
+    @classmethod
     def add(cls, host_id, hostname):
         if cls.exists('id=%s', [host_id]):
             return

--- a/web/model/host.py
+++ b/web/model/host.py
@@ -55,13 +55,13 @@ class Host(Bean):
         return ret
 
     @classmethod
-    def create(cls, hostname):
-        if cls.exists('hostname=%s', [hostname]):
-            return
-        cls.insert({'hostname': hostname})
-
-    @classmethod
     def add(cls, host_id, hostname):
         if cls.exists('id=%s', [host_id]):
             return
         cls.insert({'id': host_id, 'hostname': hostname})
+
+    @classmethod
+    def create(cls, hostname):
+        if cls.exists('hostname=%s', [hostname]):
+            return
+        cls.insert({'hostname': hostname})


### PR DESCRIPTION
#3 自定义的Endpoint，没有自动插入到host，导致无法加入到指定的主机组用于告警配置。
