### PR TITLE
trim host before add

### DIFF
--- a/web/controller/host.py
+++ b/web/controller/host.py
@@ -116,6 +116,7 @@ def host_add_post():
     failure = []
 
     for h in safe_host_arr:
+        h = h.strip()
         msg = GroupHost.bind(group_id, h)
         if not msg:
             success.append('%s<br>' % h)


### PR DESCRIPTION
trim host before add

如：

```
    192.168.1.2
    192.168.1.3
    192.168.1.4    
    192.168.1.5   
```

第一行行首的空格和最后一行行尾的空格会被清除掉
但中间几行的空格会被保留并插入数据库
